### PR TITLE
add pom.xml for maven build and deploy to Maven Central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.mindrot</groupId>
+  <artifactId>jbcrypt</artifactId>
+  <version>0.4</version>
+  <packaging>jar</packaging>
+
+  <name>jBCrypt</name>
+  <description>OpenBSD-style Blowfish password hashing for Java</description>
+  <url>https://github.com/djmdjm/jBCrypt</url>
+
+  <licenses>
+    <license>
+      <name>ISC</name>
+      <url>https://opensource.org/licenses/isc-license</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Damien Miller</name>
+      <email>djm@mindrot.org</email>
+      <organization>Mindrot.org</organization>
+      <organizationUrl>http://www.mindrot.org</organizationUrl>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:git://github.com/djmdjm/jBCrypt.git</connection>
+    <developerConnection>scm:git:ssh://github.com:djmdjm/jBCrypt.git</developerConnection>
+    <url>https://github.com/djmdjm/jBCrypt.git</url>
+  </scm>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <sourceDirectory>src</sourceDirectory>
+    <testSourceDirectory>test</testSourceDirectory>
+  </build>
+
+  <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+    <repository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+  </distributionManagement>
+
+  <profiles>
+    <profile>
+      <id>disable-java8-doclint</id>
+      <activation>
+        <jdk>[1.8,)</jdk>
+      </activation>
+      <properties>
+        <additionalparam>-Xdoclint:none</additionalparam>
+      </properties>
+    </profile>
+    <profile>
+      <id>release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.sonatype.plugins</groupId>
+            <artifactId>nexus-staging-maven-plugin</artifactId>
+            <version>1.6.7</version>
+            <extensions>true</extensions>
+            <configuration>
+              <serverId>ossrh</serverId>
+              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+              <autoReleaseAfterClose>true</autoReleaseAfterClose>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>3.0.1</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>2.10.4</version>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.6</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>


### PR DESCRIPTION
Hello, Damien. Could I interest you in a `pom.xml` for use with Apache Maven? This should be all the metadata you need to generate artifacts (jar, sources, and javadocs) and publish them to the Maven Central repository (maintained by Sonatype).

I know of [at least one](https://github.com/apache/tinkerpop) project that relies on jBCrypt that would benefit from being able to draw the artifacts from the central repo. Here's [a message thread about that very thing](https://groups.google.com/forum/#!msg/gremlin-users/ZUfKJBWYJp0/jh6A_U11AQAJ).

In addition to this file, you would need to ask Sonatype for credentials to their deployment environment. I would be happy to do it myself, but in that case, I would need your permission.

Thanks for having a look. Cheers.